### PR TITLE
Fix "Drat for ..." links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
         <h4>More</h4>
         
         You can learn more about <a href="http://dirk.eddelbuettel.com/code/drat.html">drat</a> from the vignettes
-        <a href="http://eddelbuettel.github.io/DratForPackageUsers.html">Drat for Package Users</a> and
-        <a href="http://eddelbuettel.github.io/DratForPackageAuthors.html">Drat for Package Authors</a>.
+        <a href="http://eddelbuettel.github.io/drat/DratForPackageUsers.html">Drat for Package Users</a> and
+        <a href="http://eddelbuettel.github.io/drat/DratForPackageAuthors.html">Drat for Package Authors</a>.
       </div>
       <div class="col-md-6">
         <center>


### PR DESCRIPTION
Just some minor housekeeping to keep the links to the primary resources up-to-date.
